### PR TITLE
Add pins to blogs.rstudio.com

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,7 +28,7 @@ deploy_blog () {
                 # REPO_OWNER     # REPO_NAME             # OUTPUT_DIR       # DEPLOY_DIR
 deploy_blog     rstudio          tensorflow-blog         docs               tensorflow
 deploy_blog     rstudio          cran-security-blog      public             cran-security
-
+deploy_blog     rstudio          pins                    docs/blog          pins
 
 
 


### PR DESCRIPTION
Adds https://rstudio.github.io/pins/blog since I have constant updates to share but the blog.rstudio.com is too broad to share those.