### PR TITLE
Test redirect from new ai blog

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,7 @@ deploy_blog () {
 deploy_blog     rstudio          tensorflow-blog         docs               tensorflow
 deploy_blog     rstudio          cran-security-blog      public             cran-security
 deploy_blog     rstudio          pins                    docs/blog          pins
+deploy_blog     rstudio          tensorflow-blog         redirect           ai
 
 
 


### PR DESCRIPTION
Not the real PR yet, just testing we can properly redirect from /ai to /tensorflow, next PR I'll swap them both and get everything working.