### PR TITLE
Rename tensorflow blog to ai

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ deploy_blog () {
 
 
                 # REPO_OWNER     # REPO_NAME             # OUTPUT_DIR       # DEPLOY_DIR
-deploy_blog     rstudio          tensorflow-blog         docs               tensorflow
+deploy_blog     rstudio          ai-blog                 docs               ai
 deploy_blog     rstudio          cran-security-blog      public             cran-security
 deploy_blog     rstudio          pins                    docs/blog          pins
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
-  from = "/ai"
-  to = "/tensorflow"
+  from = "/tensorflow"
+  to = "/ai"
   force = true


### PR DESCRIPTION
We know the redirects work, so this should be all good now, hopefully! `tensorflow-blog` repo already renamed to `ai-blog`.