### PR TITLE
Also redirect subpaths to new ai blog

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   from = "/tensorflow"
   to = "/ai"
   force = true
+
+[[redirects]]
+  from = "/tensorflow/*"
+  to = "/ai/:splat"
+  force = true


### PR DESCRIPTION
We also want to redirect URLs like: [blogs.rstudio.com/tensorflow/posts/2020-02-19-kl-divergence/](https://blogs.rstudio.com/tensorflow/posts/2020-02-19-kl-divergence/)